### PR TITLE
Send auth headers to php-fpm backend

### DIFF
--- a/centos/nextcloud.conf
+++ b/centos/nextcloud.conf
@@ -1,5 +1,3 @@
-ProxyPassMatch ^/nextcloud/(.*\.php(/.*)?)$ fcgi://127.0.0.1:9000/usr/share/nextcloud/$1
-
 Alias /nextcloud "/usr/share/nextcloud/"
 <Directory "/usr/share/nextcloud">
   Options +FollowSymLinks
@@ -10,8 +8,13 @@ Alias /nextcloud "/usr/share/nextcloud/"
         Dav off
   </IfModule>
 
+  <FilesMatch \.php$>
+        SetHandler "proxy:fcgi://127.0.0.1:9000"
+  </FilesMatch>
+
   SetEnv HOME /usr/share/nextcloud
   SetEnv HTTP_HOME /usr/share/nextcloud
+  SetEnvIf Authorization "(.*)" HTTP_AUTHORIZATION=$1
 </Directory>
 
 <Directory "/usr/share/nextcloud/data/">

--- a/centos/nextcloud.spec
+++ b/centos/nextcloud.spec
@@ -70,8 +70,9 @@ cp %{SOURCE1} %{buildroot}/etc/httpd/conf.d
 %attr(0775,%{nc_user},%{nc_group}) %{nc_data_dir}
 %attr(0775,%{nc_user},%{nc_group}) %{nc_config_dir}
 
-%config %attr(0644,%{nc_user},%{nc_group}) %{nc_dir}/.htaccess
-/etc/httpd/conf.d/nextcloud.conf
+%config(noreplace) %attr(0644,%{nc_user},%{nc_group}) %{nc_dir}/.user.ini
+%config(noreplace) %attr(0644,%{nc_user},%{nc_group}) %{nc_dir}/.htaccess
+%config(noreplace) %attr(0644,root,root) /etc/httpd/conf.d/nextcloud.conf
 
 %defattr(0644,%{nc_user},%{nc_group},0755)
 


### PR DESCRIPTION
Fixes the WebDAV authentication

Also

* Fixes handling of files with a name containing white spaces
* Fixes permissions on configuration files, preventing override of local modifications

NethServer/dev#5263

See also:

http://community.nethserver.org/t/nextcloud-11-and-webdav/6451