### PR TITLE
spec: remove python byte compilation

### DIFF
--- a/centos/nextcloud.spec
+++ b/centos/nextcloud.spec
@@ -9,6 +9,9 @@
 %define nc_user apache
 %define nc_group apache
 
+# Turn off the brp-python-bytecompile script
+%global __os_install_post %(echo '%{__os_install_post}' | sed -e 's!/usr/lib[^[:space:]]*/brp-python-bytecompile[[:space:]].*$!!g')
+
 
 Summary: Nextcloud package
 Name: nextcloud


### PR DESCRIPTION
**Problem**
After the update there is a warning message in the admin account about the integrity check failed.
The cause is the presence of .pyc and .pyo files.
This PR disable the creation of these files.