### PR TITLE
spec: remove "config" sign from .htaccess

### DIFF
--- a/centos/nextcloud.spec
+++ b/centos/nextcloud.spec
@@ -85,9 +85,9 @@ cp %{SOURCE1} %{buildroot}/etc/httpd/conf.d
 %attr(0755,%{nc_user},%{nc_group}) %{nc_dir}/db_structure.xml
 %attr(0755,%{nc_user},%{nc_group}) %{nc_dir}/index.html
 %attr(0755,%{nc_user},%{nc_group}) %{nc_dir}/robots.txt
+%attr(0644,%{nc_user},%{nc_group}) %{nc_dir}/.htaccess
 
 %config(noreplace) %attr(0644,%{nc_user},%{nc_group}) %{nc_dir}/.user.ini
-%config(noreplace) %attr(0644,%{nc_user},%{nc_group}) %{nc_dir}/.htaccess
 %config(noreplace) %attr(0644,root,root) /etc/httpd/conf.d/nextcloud.conf
 
 %defattr(0644,%{nc_user},%{nc_group},0755)

--- a/centos/nextcloud.spec
+++ b/centos/nextcloud.spec
@@ -16,7 +16,7 @@
 Summary: Nextcloud package
 Name: nextcloud
 Version: %nextcloud_version
-Release: 1%{?dist}
+Release: 2%{?dist}
 License: GPL
 Source: https://download.nextcloud.com/server/releases/nextcloud-%{nextcloud_version}.tar.bz2
 Source1: nextcloud.conf
@@ -94,6 +94,9 @@ cp %{SOURCE1} %{buildroot}/etc/httpd/conf.d
 
 
 %changelog
+* Mon Jan 15 2018 Alessandro Polidori <alessandro.polidori@nethesis.it> - centos-12.0.4-2
+- Spec: remove "config" sign from .htaccess
+
 * Thu Dec 14 2017 Giacomo Sanchietti <giacomo.sanchietti@nethesis.it> - centos-12.0.4-1
 - Update to release 12.0.4
 


### PR DESCRIPTION
`.htaccess` signed as config file cause a problem.

**How to riproduce**
1. install nextcloud 11.0.3
2. update to 12.0.4
3. `/usr/share/nextcloud/.htaccess.rpmnew` has been created
4. nextcloud admin page shows a warning message of integrity check and a security warning

![nextcloud](https://user-images.githubusercontent.com/1625334/34784785-8efa2d58-f62f-11e7-99e1-fde825c5bfca.PNG)

**Expected behavior**
The update ends and no security warning appears

**Solution proposal**
This PR umark .htaccess as config file.
If you are in update scenario, after the package installation you must remove .rpmnew and .rpmsave files 
 and execute the command "occ integrity:check-core".
If you have some other rpm that manage the installation & configuration of nextcloud package, this must be adapted (as for example with [nethserver-nextcloud PR](https://github.com/NethServer/nethserver-nextcloud/pull/24)).