### PR TITLE
V14

### DIFF
--- a/centos/README.md
+++ b/centos/README.md
@@ -1,6 +1,22 @@
 Nextcloud
 =========
 
+
+End of Life Notice
+------------------
+NextCloud 14 is stated to be End of Life as of September 2019
+
+Past the EoL date there will no longer be security or maintenance fixes
+provided.  It is important to plan accordingly.
+
+Also NextCloud does not support skipping major versions.  To keep the
+database schema current, it is important to run the upgrade (such as 
+through the OCC CLI) for each major version.
+
+
+About
+-----
+
 This repository can be used to build a very basic RPM suited for CentOS 7.
 It uses Apache 2.4 with PHP-FPM to avoid conflicts with existing 
 PHP 5.4 applications.  This also running Apache with a multi-threaded MPM

--- a/centos/README.md
+++ b/centos/README.md
@@ -19,8 +19,9 @@ About
 
 This repository can be used to build a very basic RPM suited for CentOS 7.
 It uses Apache 2.4 with PHP-FPM to avoid conflicts with existing 
-PHP 5.4 applications.  This also running Apache with a multi-threaded MPM
-while using mod_php a multi-threaded MPM is not recommended.
+PHP 5.4 applications.  This also allows running Apache with a 
+multi-threaded MPM while using mod_php a multi-threaded MPM is 
+not recommended.
 
 The package has been built following official Nextcloud documentation and
 guidelines about strong directory permissions. See: https://docs.nextcloud.org/
@@ -61,7 +62,7 @@ The following dependencies are installed:
 * PHP packages for builtin apps (php-ldap)
 * PHP packages for MariaDB/MySQL connection
 
-You need to enable EPEL  and SCL repositories.
+You need to enable EPEL and SCL repositories.
 
 On CentOS this can be done by running:
 

--- a/centos/nextcloud.spec
+++ b/centos/nextcloud.spec
@@ -12,7 +12,7 @@
 
 Summary: Nextcloud package
 Name: nextcloud
-Version: 14.0.9
+Version: 14.0.10
 Release: 1%{?dist}
 License: GPL
 Source: https://download.nextcloud.com/server/releases/nextcloud-%{version}.tar.bz2
@@ -116,6 +116,9 @@ cp %{SOURCE1} %{buildroot}/etc/httpd/conf.d
 
 
 %changelog
+* Thu Apr 8 2019 B Galliart <ben@steadfast.net> - 14.0.10-1
+- Update to release 14.0.10
+
 * Thu Apr 4 2019 B Galliart <ben@steadfast.net> - 14.0.9-1
 - Update to release 14.0.9
 

--- a/centos/nextcloud.spec
+++ b/centos/nextcloud.spec
@@ -12,7 +12,7 @@
 
 Summary: Nextcloud package
 Name: nextcloud
-Version: 14.0.10
+Version: 14.0.11
 Release: 1%{?dist}
 License: GPL
 Source: https://download.nextcloud.com/server/releases/nextcloud-%{version}.tar.bz2
@@ -45,6 +45,8 @@ Requires: rh-php71-php-ldap
 # Required php packages for MariaDB
 Requires: rh-php71-php-pdo_mysql
 
+# NextCloud does not support skipping a major version number
+Conflicts: nextcloud < 13
 
 %description
 Nextcloud files and configuration.
@@ -85,6 +87,23 @@ mkdir -p %{buildroot}/etc/httpd/conf.d
 cp %{SOURCE1} %{buildroot}/etc/httpd/conf.d
 
 
+%post
+cat << EOF
+-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
+NextCloud End of Life Notice
+-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
+This NextCloud version is stated to be End of Life as of September 2019
+
+Past the EoL date there will no longer be security or maintenance fixes
+provided.  It is important to plan an upgrade schedule accordingly.
+
+Also NextCloud does not support skipping major versions.  To keep the
+database schema current, it is important to run the upgrade (such as 
+through the OCC CLI) for each major version.
+-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
+EOF
+
+
 %files 
 %defattr(0640,root,%{nc_group},0750)
 %dir %attr(0755,root,%{nc_group}) %{nc_dir}
@@ -116,6 +135,10 @@ cp %{SOURCE1} %{buildroot}/etc/httpd/conf.d
 
 
 %changelog
+* Thu May 16 2019 B Galliart <ben@steadfast.net> - 14.0.11-1
+- Update to release 14.0.11
+- Added EoL warning notice for v14
+
 * Thu Apr 8 2019 B Galliart <ben@steadfast.net> - 14.0.10-1
 - Update to release 14.0.10
 

--- a/centos/nextcloud.spec
+++ b/centos/nextcloud.spec
@@ -220,3 +220,4 @@ EOF
 * Mon Aug 01 2016 Giacomo Sanchietti <giacomo.sanchietti@nethesis.it> - 9.0.53-2
 - First Nextcloud release - NethServer/dev#5055
 
+


### PR DESCRIPTION
Update to 14.0.11

Upstream Nextcloud project expects to release 14.0.12 in August and then End of Life v14 in September.

An EoL notice has been added to reflect the fact we are only a couple releases away from EoL for this major version.  It also noted that Nextcloud does not support skipping a major version when performing upgraded.